### PR TITLE
Fixed data parsing for V2 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,26 @@
 
 A scratch page to work through the [Connections game](https://nytimes.com/games/connections).
 
-This uses _extremely_ fragile web scraping.
+## Running locally
+
+This is a node app. To install packages, from the root directory, type:
+
+```bash
+npm install
+```
+
+To run at `http://localhost:5500`:
+
+```bash
+npm start
+```
+
+## Using local data
+
+In `app.js`:
+
+-   Change `IS_DEV` from `false` to `true` to use local data, rather than hitting the Times API.
+
+Current data format (as of 2025-09-20):
+
+`testData/testJson2025-09-20.json`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connectionsscratchsheet",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple scratch sheet to help solve Connections",
   "main": "app.js",
   "type": "module",

--- a/public/index.html
+++ b/public/index.html
@@ -17,9 +17,6 @@
                 <button id="delete-one" class="two-step-button">
                     Delete one
                 </button>
-                <!-- <button id="reset-size" class="two-step-button">
-                    Reset size
-                </button> -->
                 <button id="get-history" class="two-step-button">
                     Past results
                 </button>

--- a/public/index.js
+++ b/public/index.js
@@ -56,12 +56,13 @@ const renderPage = (data) => {
     //  two-step buttons at top
     const deleteOneButton = document.getElementById("delete-one");
     const deleteAllButton = document.getElementById("delete-all");
-    // const resetSizeButton = document.getElementById("reset-size");
     const resetGridButton = document.getElementById("reset-grid");
     const getHistoryButton = document.getElementById("get-history");
 
     //  disable resetGridButton until something has moved
     resetGridButton.disabled = true;
+    //  TEMP: disable getHistory button until adjusted for v2 data
+    getHistoryButton.disabled = true;
 
     const twoStepButtonMap = new Map();
     twoStepButtonMap.set("delete-one", deleteOneButton);

--- a/testData/testJson2025-09-19.json
+++ b/testData/testJson2025-09-19.json
@@ -1,0 +1,44 @@
+{
+    "status": "OK",
+    "id": 866,
+    "print_date": "2025-09-19",
+    "editor": "Wyna Liu",
+    "categories": [
+        {
+            "title": "EVALUATE",
+            "cards": [
+                { "content": "GRADE", "position": 15 },
+                { "content": "RANK", "position": 12 },
+                { "content": "RATE", "position": 4 },
+                { "content": "SCORE", "position": 10 }
+            ]
+        },
+        {
+            "title": "EXHIBIT NERVOUSNESS",
+            "cards": [
+                { "content": "BLUSH", "position": 5 },
+                { "content": "FIDGET", "position": 13 },
+                { "content": "PACE", "position": 3 },
+                { "content": "SWEAT", "position": 8 }
+            ]
+        },
+        {
+            "title": "THINGS THAT CAN RUN, ANNOYINGLY",
+            "cards": [
+                { "content": "DYE", "position": 6 },
+                { "content": "MASCARA", "position": 2 },
+                { "content": "NOSE", "position": 1 },
+                { "content": "STOCKINGS", "position": 14 }
+            ]
+        },
+        {
+            "title": "PAPER ___",
+            "cards": [
+                { "content": "CLIP", "position": 7 },
+                { "content": "TIGER", "position": 0 },
+                { "content": "TOWEL", "position": 9 },
+                { "content": "TRAIL", "position": 11 }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Fixed the data parsing for V2 of the NY Times API. Results sheet disabled.